### PR TITLE
Generate the argument name based on the typehint

### DIFF
--- a/spec/Cjm/PhpSpec/Argument/StringBuilderSpec.php
+++ b/spec/Cjm/PhpSpec/Argument/StringBuilderSpec.php
@@ -3,7 +3,6 @@
 namespace spec\Cjm\PhpSpec\Argument;
 
 use Cjm\PhpSpec\Argument\ClassIdentifier;
-use Cjm\PhpSpec\Argument\StringBuilder;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -14,10 +13,15 @@ class StringBuilderSpec extends ObjectBehavior
         $this->beConstructedWith($classIdentifier);
     }
 
-    function it_should_use_type_hints_from_class_identifier(ClassIdentifier $classIdentifier)
+    function it_should_use_generic_name_with_index_for_non_object_argument(ClassIdentifier $classIdentifier)
+    {
+        $this->buildFrom(array(2))->shouldReturn('$argument1');
+    }
+
+    function it_should_use_typehint_to_name_object_argument(ClassIdentifier $classIdentifier)
     {
         $classIdentifier->getTypeName(Argument::any())->willReturn('ArrayObject');
 
-        $this->buildFrom(array(new \ArrayObject(), 2))->shouldReturn('\ArrayObject $arrayObject, $argument2');
+        $this->buildFrom(array(new \ArrayObject()))->shouldReturn('\ArrayObject $arrayObject');
     }
 }

--- a/spec/Cjm/PhpSpec/Argument/StringBuilderSpec.php
+++ b/spec/Cjm/PhpSpec/Argument/StringBuilderSpec.php
@@ -18,6 +18,6 @@ class StringBuilderSpec extends ObjectBehavior
     {
         $classIdentifier->getTypeName(Argument::any())->willReturn('ArrayObject');
 
-        $this->buildFrom(array(new \ArrayObject(), 2))->shouldReturn('\ArrayObject $argument1, $argument2');
+        $this->buildFrom(array(new \ArrayObject(), 2))->shouldReturn('\ArrayObject $arrayObject, $argument2');
     }
 }

--- a/spec/Cjm/PhpSpec/Argument/StringBuilderSpec.php
+++ b/spec/Cjm/PhpSpec/Argument/StringBuilderSpec.php
@@ -15,23 +15,23 @@ class StringBuilderSpec extends ObjectBehavior
 
     function it_should_use_generic_name_for_non_object_argument(ClassIdentifier $classIdentifier)
     {
-        $this->buildFrom(array(2))->shouldReturn('$argument1');
+        $this->buildFrom(array(2))->shouldReturn('$argument');
     }
 
     function it_should_use_typehint__for_object_and_name_it_after_its_type(ClassIdentifier $classIdentifier)
     {
         $classIdentifier->getTypeName(Argument::any())->willReturn('ArrayObject');
 
-        $this->buildFrom(array(new \ArrayObject()))->shouldReturn('\ArrayObject $arrayObject1');
+        $this->buildFrom(array(new \ArrayObject()))->shouldReturn('\ArrayObject $arrayObject');
     }
 
-    function it_should_use_index_to_avoid_name_collision(ClassIdentifier $classIdentifier)
+    function it_should_suffix_names_when_necessary_to_avoid_name_collision(ClassIdentifier $classIdentifier)
     {
         $classIdentifier->getTypeName(Argument::any())->willReturn('ArrayObject');
 
         $this
             ->buildFrom(array(new \ArrayObject(), new \ArrayObject(), 1, 2))
-            ->shouldReturn('\ArrayObject $arrayObject1, \ArrayObject $arrayObject2, $argument3, $argument4')
+            ->shouldReturn('\ArrayObject $arrayObject1, \ArrayObject $arrayObject2, $argument1, $argument2')
         ;
     }
 }

--- a/spec/Cjm/PhpSpec/Argument/StringBuilderSpec.php
+++ b/spec/Cjm/PhpSpec/Argument/StringBuilderSpec.php
@@ -13,15 +13,25 @@ class StringBuilderSpec extends ObjectBehavior
         $this->beConstructedWith($classIdentifier);
     }
 
-    function it_should_use_generic_name_with_index_for_non_object_argument(ClassIdentifier $classIdentifier)
+    function it_should_use_generic_name_for_non_object_argument(ClassIdentifier $classIdentifier)
     {
         $this->buildFrom(array(2))->shouldReturn('$argument1');
     }
 
-    function it_should_use_typehint_to_name_object_argument(ClassIdentifier $classIdentifier)
+    function it_should_use_typehint__for_object_and_name_it_after_its_type(ClassIdentifier $classIdentifier)
     {
         $classIdentifier->getTypeName(Argument::any())->willReturn('ArrayObject');
 
-        $this->buildFrom(array(new \ArrayObject()))->shouldReturn('\ArrayObject $arrayObject');
+        $this->buildFrom(array(new \ArrayObject()))->shouldReturn('\ArrayObject $arrayObject1');
+    }
+
+    function it_should_use_index_to_avoid_name_collision(ClassIdentifier $classIdentifier)
+    {
+        $classIdentifier->getTypeName(Argument::any())->willReturn('ArrayObject');
+
+        $this
+            ->buildFrom(array(new \ArrayObject(), new \ArrayObject(), 1, 2))
+            ->shouldReturn('\ArrayObject $arrayObject1, \ArrayObject $arrayObject2, $argument3, $argument4')
+        ;
     }
 }

--- a/src/Cjm/PhpSpec/Argument/StringBuilder.php
+++ b/src/Cjm/PhpSpec/Argument/StringBuilder.php
@@ -26,7 +26,7 @@ class StringBuilder
         $argumentStrings = array();
 
         foreach ($arguments as $key=>$argument){
-            $argumentStrings[] = $this->getTypeHint($argument) . $this->getArgName($key);
+            $argumentStrings[] = $this->getTypeHint($argument) . $this->getArgName($key, $argument);
         }
 
         return join(', ', $argumentStrings);
@@ -49,12 +49,18 @@ class StringBuilder
 
     /**
      * @param $key
+     * @param $argument
      * @return string
      */
-    private function getArgName($key)
+    private function getArgName($key, $argument)
     {
-        $argName = '$argument' . ($key + 1);
+        if (!is_object(($argument))) {
+            return '$argument' . ($key + 1);
+        }
+        $typeHint = $this->classIdentifier->getTypeName($argument);
+        $parts = explode('\\', $typeHint);
+        $className = end($parts);
 
-        return $argName;
+        return lcfirst($className);
     }
 }

--- a/src/Cjm/PhpSpec/Argument/StringBuilder.php
+++ b/src/Cjm/PhpSpec/Argument/StringBuilder.php
@@ -61,6 +61,6 @@ class StringBuilder
         $parts = explode('\\', $typeHint);
         $className = end($parts);
 
-        return '$'.lcfirst($className);
+        return '$'.lcfirst($className) . ($key + 1);
     }
 }

--- a/src/Cjm/PhpSpec/Argument/StringBuilder.php
+++ b/src/Cjm/PhpSpec/Argument/StringBuilder.php
@@ -61,6 +61,6 @@ class StringBuilder
         $parts = explode('\\', $typeHint);
         $className = end($parts);
 
-        return lcfirst($className);
+        return '$'.lcfirst($className);
     }
 }

--- a/src/Cjm/PhpSpec/Argument/StringBuilder.php
+++ b/src/Cjm/PhpSpec/Argument/StringBuilder.php
@@ -24,9 +24,18 @@ class StringBuilder
     public function buildFrom($arguments)
     {
         $argumentStrings = array();
-
-        foreach ($arguments as $key=>$argument){
-            $argumentStrings[] = $this->getTypeHint($argument) . $this->getArgName($key, $argument);
+        foreach ($arguments as $key => $argument){
+            $argumentStrings[] = $this->getTypeHint($argument).$this->getArgName($argument);
+        }
+        $allCount = array_count_values($argumentStrings);
+        $duplicatesCount = array_filter($allCount, function ($count) {
+            return 1 < $count;
+        });
+        for ($i = count($argumentStrings) - 1; $i >= 0; $i--) {
+            if (isset($duplicatesCount[$argumentStrings[$i]])) {
+                $duplicatesCount[$argumentStrings[$i]]--;
+                $argumentStrings[$i] .= $duplicatesCount[$argumentStrings[$i]] + 1;
+            }
         }
 
         return join(', ', $argumentStrings);
@@ -39,28 +48,26 @@ class StringBuilder
     private function getTypeHint($argument)
     {
         $typeHint = '';
-
-        if (is_object(($argument))) {
-            $typeHint .= '\\' . $this->classIdentifier->getTypeName($argument) . ' ';
+        if (is_object($argument)) {
+            $typeHint .= '\\'.$this->classIdentifier->getTypeName($argument).' ';
         }
 
         return $typeHint;
     }
 
     /**
-     * @param $key
      * @param $argument
      * @return string
      */
-    private function getArgName($key, $argument)
+    private function getArgName($argument)
     {
-        if (!is_object(($argument))) {
-            return '$argument' . ($key + 1);
+        if (!is_object($argument)) {
+            return '$argument';
         }
         $typeHint = $this->classIdentifier->getTypeName($argument);
         $parts = explode('\\', $typeHint);
         $className = end($parts);
 
-        return '$'.lcfirst($className) . ($key + 1);
+        return '$'.lcfirst($className);
     }
 }


### PR DESCRIPTION
Currently the generated argument name is "$argument1", "$argument2", etc.
But if the argument is typehinted, we can name it after its type, for e.g. "$urlGenerator" or "$flabbergastRepository".