### PR TITLE
Improved Composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "autoload": {
-        "psr-0": { "": "src/" }
+        "psr-4": { "Cjm\\PhpSpec\\": "src/Cjm/PhpSpec" }
     },
     "config": {
         "bin-dir" : "bin"


### PR DESCRIPTION
Using prefixed PSR-4 autoloading will avoid unnecessary "file_exists" checks on Composer side.