### PR TITLE
Switching to PhpSpec 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "bin-dir" : "bin"
     },
     "require": {
-        "phpspec/phpspec": "~3.0"
+        "phpspec/phpspec": "4.0.0-rc1"
     },
     "require-dev": {
         "behat/behat": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "bin-dir" : "bin"
     },
     "require": {
+        "php": "^7.0",
         "phpspec/phpspec": "^4.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "bin-dir" : "bin"
     },
     "require": {
-        "phpspec/phpspec": "4.0.0-rc1"
+        "phpspec/phpspec": "^4.0"
     },
     "require-dev": {
         "behat/behat": "~3.0",

--- a/src/Generator/TypeHintedMethodGenerator.php
+++ b/src/Generator/TypeHintedMethodGenerator.php
@@ -45,14 +45,7 @@ class TypeHintedMethodGenerator implements Generator
         $this->filesystem = $filesystem ?: new Filesystem;
     }
 
-    /**
-     * @param Resource $resource
-     * @param string   $generation
-     * @param array    $data
-     *
-     * @return bool
-     */
-    public function supports(Resource $resource, $generation, array $data)
+    public function supports(Resource $resource, string $generation, array $data) : bool
     {
         return 'method' === $generation;
     }
@@ -88,10 +81,7 @@ class TypeHintedMethodGenerator implements Generator
             ), 2);
     }
 
-    /**
-     * @return int
-     */
-    public function getPriority()
+    public function getPriority() : int
     {
         return 0;
     }


### PR DESCRIPTION
Changes method signatures for compatibility with PhpSpec 4.

~~WIP because it puts `"phpspec/phpspec": "4.0.0-rc1"` in `composer.json` for now.~~

Now uses stable PhpSpec 4 release