### PR TITLE
Integrate Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+
+sudo: false
+
+dist: trusty
+
+matrix:
+  include:
+    - php: 7.0
+      env: COMPOSER_ARGS='--prefer-lowest'
+    - php: 7.0
+    - php: 7.1
+    - php: nightly
+  allow_failures:
+    - php: nightly
+
+before_script:
+  - composer update $COMPOSER_ARGS
+
+script:
+  - ./bin/phpspec run

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/ciaranmcnulty/phpspec-typehintedmethods.svg?branch=master)](https://travis-ci.org/ciaranmcnulty/phpspec-typehintedmethods)
+
 #PhpSpec Typehinted Methods Extension
 
 ##Usage


### PR DESCRIPTION
Adds Travis CI config file, and adds a badge to the readme.

You would have to enable the build process on the [add repositories page](https://travis-ci.org/profile/ciaranmcnulty) on the Travis CI website as well.

The build for this branch is currently green on my fork.