### PR TITLE
Adding implicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require": {
         "php": "^7.0",
-        "phpspec/phpspec": "^4.0"
+        "phpspec/phpspec": "^4.0",
+        "phpspec/prophecy": "^1.6"
     },
     "require-dev": {
         "behat/behat": "~3.0",


### PR DESCRIPTION
Adding Prophecy as a dependency, as it is being used by `Cjm\PhpSpec\Argument\ClassIdentifier`.

Pinning to this minimum version, as opposed to `1.5`, fixes the build.