### PR TITLE
Make Composer run on canary build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: nightly
+      env: COMPOSER_ARGS='--ignore-platform-reqs'
   allow_failures:
     - php: nightly
 


### PR DESCRIPTION
Make Composer run on canary build, despite PhpSpec's stated language version requirements